### PR TITLE
Allow custom paths to includes and libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,83 +3,12 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "aoflagger_sys"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
- "bindgen",
  "cc",
  "cxx",
  "cxx-build",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453c49e5950bb0eb63bb3df640e31618846c89d5b7faa54040d76e98e0134375"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "clap",
- "env_logger",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "which",
-]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitvec"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
 ]
 
 [[package]]
@@ -89,47 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 dependencies = [
  "jobserver",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db507a7679252d2276ed0dd8113c6875ec56d3089f9225b2b42c30cc1f8e5c89"
-dependencies = [
- "nom",
-]
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "clang-sys"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cf2cc85830eae84823884db23c5306442a6c3d5bfd3beb2f2a2c829faa1816"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
-name = "clap"
-version = "2.33.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -187,46 +75,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
-
-[[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "jobserver"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,26 +90,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
-
-[[package]]
-name = "libloading"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
-dependencies = [
- "cfg-if",
- "winapi",
-]
 
 [[package]]
 name = "link-cplusplus"
@@ -271,39 +103,6 @@ checksum = "8f1becd27d473556dc610b8afa1636ef90747b574a84553bc11e82371d5ef2d1"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "log"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "memchr"
-version = "2.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
-
-[[package]]
-name = "nom"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
-dependencies = [
- "bitvec",
- "funty",
- "memchr",
- "version_check",
-]
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "proc-macro2"
@@ -324,51 +123,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
-
-[[package]]
-name = "regex"
-version = "1.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
 name = "scratch"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e114536316b51a5aa7a0e59fc49661fd263c5507dd08bd28de052e57626ce69"
-
-[[package]]
-name = "shlex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
-
-[[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
@@ -382,27 +140,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -416,27 +159,6 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
-
-[[package]]
-name = "which"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "winapi"
@@ -468,9 +190,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aoflagger_sys"
 description = "Rust bindings for the aoflagger C++ library"
-version = "0.1.0"
+version = "0.1.1"
 homepage = "https://github.com/MWATelescope/rust-aoflagger"
 repository = "https://github.com/MWATelescope/rust-aoflagger"
 authors = ["Derwent McElhinney <derwent.mcelhinney@curtin.edu.au>"]
@@ -17,6 +17,5 @@ links = "aoflagger"
 cxx = "1.0"
 
 [build-dependencies]
-bindgen = "0.59"
 cc = {version = "1.0", features = ["parallel"]}
 cxx-build = "1.0.54"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <img alt="Crates.io" src="https://img.shields.io/crates/d/aoflagger_sys?label=crates.io%20%E2%AC%87%EF%B8%8F"></a>
 <a href="https://docs.rs/crate/aoflagger_sys/">
   <img src="https://docs.rs/aoflagger_sys/badge.svg" alt="codecov"></a>
-<a href="https://codecov.io/gh/MWATelescope/rust-aoflagger"> 
+<a href="https://codecov.io/gh/MWATelescope/rust-aoflagger">
   <img src="https://codecov.io/gh/MWATelescope/rust-aoflagger/branch/main/graph/badge.svg?token=PK2KYEZOW9" alt="codecov"></a>
 <a href="https://rust-reportcard.xuri.me/report/github.com/mwatelescope/rust-aoflagger">
   <img src="https://rust-reportcard.xuri.me/badge/github.com/mwatelescope/rust-aoflagger" alt="rust-reportcard"></a>
@@ -29,13 +29,21 @@ Rust bindings for <https://gitlab.com/aroffringa/aoflagger>
 
 ### Prerequisites
 
-- A Rust compiler with a version >= 1.51.0 - <https://www.rust-lang.org/tools/install>
-- [AOFlagger](https://gitlab.com/aroffringa/aoflagger) >= 3.0
-  (Ubuntu > 21.04: apt install aoflagger-dev)
-- [CFitsIO](https://heasarc.gsfc.nasa.gov/fitsio/) >= 3.49
-  (Ubuntu > 20.10: apt install libcfitsio-dev)
+`aoflagger_sys` itself only requires
+[`AOFlagger`](https://gitlab.com/aroffringa/aoflagger), version >= 3.0, but that
+requires many dependencies. On Ubuntu > 21.04, `apt install aoflagger-dev` is
+enough, but for OS-specific instructions, check out the
+[linux](https://github.com/MWATelescope/rust-aoflagger/blob/main/.github/workflows/linux_test.yml)
+and
+[macOS](https://github.com/MWATelescope/rust-aoflagger/blob/main/.github/workflows/macos_test.yml)
+CI Scripts and the
+[Makefile.toml](https://github.com/MWATelescope/rust-aoflagger/blob/main/Makefile.toml)
+as these are tested regularly. The instructions below may be updated less
+frequently, but are better documented.
 
-for OS-specific instructions, check out the [linux](https://github.com/MWATelescope/rust-aoflagger/blob/main/.github/workflows/linux_test.yml) and [macOS](https://github.com/MWATelescope/rust-aoflagger/blob/main/.github/workflows/macos_test.yml) CI Scripts and the [Makefile.toml](https://github.com/MWATelescope/rust-aoflagger/blob/main/Makefile.toml) as these are tested regularly. The instructions below may be updated less frequently, but are better documented.
+If `AOFlagger` is in a non-standard location, `AOFLAGGER_INCLUDE_DIR` and
+`AOFLAGGER_LIB` may be set to the include and library directories, respectively,
+which allows `aoflagger_sys` to find the correct files.
 
 ### (Debian/Ubuntu) Linux Setup
 

--- a/build.rs
+++ b/build.rs
@@ -6,16 +6,31 @@ fn main() {
     match env::var("DOCS_RS").as_deref() {
         Ok("1") => (),
         _ => {
-            cxx_build::bridge("src/cxx_aoflagger.rs")
+            let mut build = cxx_build::bridge("src/cxx_aoflagger.rs");
+            build
                 .flag_if_supported("-std=c++11")
                 .flag_if_supported("-Wno-nonportable-include-path")
                 .flag_if_supported("-Wno-unused-parameter")
-                .file("src/cxx_aoflagger.cc")
-                .compile("cxx_aoflagger");
+                .file("src/cxx_aoflagger.cc");
+            // Tell cargo to search for includes in AOFLAGGER_INCLUDE_DIR, if
+            // it's defined.
+            if let Ok(dir) = std::env::var("AOFLAGGER_INCLUDE_DIR") {
+                build.include(dir);
+            }
+            build.compile("cxx_aoflagger");
             // Tell cargo to tell rustc to link the aoflagger shared library.
             println!("cargo:rustc-link-lib=dylib=aoflagger");
+            // Tell cargo to search in the library dir AOFLAGGER_LIB, if it's
+            // defined.
+            if let Ok(lib) = std::env::var("AOFLAGGER_LIB") {
+                println!("cargo:rustc-link-search=native={lib}");
+            }
         }
     }
+
+    println!("cargo:rerun-if-env-changed=AOFLAGGER_INCLUDE_DIR");
+    println!("cargo:rerun-if-env-changed=AOFLAGGER_LIB");
+
     println!("cargo:rerun-if-changed=src/cxx_aoflagger.rs");
     println!("cargo:rerun-if-changed=src/cxx_aoflagger.cc");
 


### PR DESCRIPTION
A custom path to aoflagger includes can be given with
AOFLAGGER_INCLUDE_DIR and a custom path to aoflagger libs can be given
with AOFLAGGER_LIB.

Also remove bindgen as a dependency; it wasn't used.

Also clean up the README.